### PR TITLE
Update mask-length-range for system-loopbacks prefix

### DIFF
--- a/startup_configs/spine.conf
+++ b/startup_configs/spine.conf
@@ -31,7 +31,7 @@
 # --8<-- [start:ebgp-underlay]
 / routing-policy {
     prefix-set system-loopbacks {
-        prefix 10.0.0.0/8 mask-length-range 8..32 {
+        prefix 10.0.0.0/8 mask-length-range 32..32 {
         }
     }
     policy system-loopbacks-policy {


### PR DESCRIPTION
Leaf1 and 2 use /32 and a mask-length-range 32..32. I guess it would make sense to use 32..32 on the spine as well or did I miss something?